### PR TITLE
fix: Update type and default value for parameter length

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,10 @@ Invoke-psake .\src\build.ps1 -taskList Build
 # Build and publish
 Invoke-psake .\src\build.ps1 -taskList Publish
 ```
+
+### Clean up
+
+```powershell
+# Clean up module dir
+Invoke-psake .\src\Build.ps1 -taskList Clean
+```

--- a/docs/New-RandomPassword.md
+++ b/docs/New-RandomPassword.md
@@ -175,8 +175,8 @@ Length of the password to generate.
 Default is 16.
 
 ```yaml
-Type: SwitchParameter
-Default value: false
+Type: System.Int32
+Default value: 16
 Supports wildcards: false
 ```
 


### PR DESCRIPTION
- Add clean up instructions to README file
- Update parameter type and default value for -Length in New-RandomPassword help file